### PR TITLE
[ fix ] - Not printing Iteration info in log file

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -292,10 +292,12 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
         }
 
         if (net.cudnn_half) {
-            if (iteration < net.burn_in * 3) fprintf(stderr, "\n Tensor Cores are disabled until the first %d iterations are reached.", 3 * net.burn_in);
-            else fprintf(stderr, "\n Tensor Cores are used.");
+            if (iteration < net.burn_in * 3) fprintf(stderr, "\n Tensor Cores are disabled until the first %d iterations are reached.\n", 3 * net.burn_in);
+            else fprintf(stderr, "\n Tensor Cores are used.\n");
+            fflush(stderr);
         }
         printf("\n %d: %f, %f avg loss, %f rate, %lf seconds, %d images, %f hours left\n", iteration, loss, avg_loss, get_current_rate(net), (what_time_is_it_now() - time), iteration*imgs, avg_time);
+        fflush(stdout);
 
         int draw_precision = 0;
         if (calc_map && (iteration >= next_map_calc || iteration == net.max_batches)) {


### PR DESCRIPTION
When we redirect output of training into log files, while the net.cudnn_half is True, iteration information line, which contains "avg loss" is missed.
Using \n and fflush() fixed the issue. Each one of them may be enough to fix the issue.